### PR TITLE
feat(auth): add JWT-based authorization flow with Jotai

### DIFF
--- a/Source Code/chowhub/src/components/LogoutButton.jsx
+++ b/Source Code/chowhub/src/components/LogoutButton.jsx
@@ -1,0 +1,23 @@
+// src/components/LogoutButton.jsx
+import { useSetAtom } from 'jotai';
+import { tokenAtom, userAtom } from '@/store/atoms';
+import { useRouter } from 'next/router';
+
+export default function LogoutButton() {
+  const setToken = useSetAtom(tokenAtom);
+  const setUser  = useSetAtom(userAtom);
+  const router   = useRouter();
+
+  return (
+    <button
+      className="btn btn-outline-danger btn-sm"
+      onClick={() => {
+        setToken(null);
+        setUser(null);
+        router.push('/login');
+      }}
+    >
+      Logout
+    </button>
+  );
+}

--- a/Source Code/chowhub/src/components/Protected.jsx
+++ b/Source Code/chowhub/src/components/Protected.jsx
@@ -1,0 +1,25 @@
+import { useAtomValue } from 'jotai';
+import { tokenAtom, userAtom } from '@/store/atoms';   
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function Protected({ children }) {
+  const token = useAtomValue(tokenAtom);
+  const user  = useAtomValue(userAtom);              
+  const router = useRouter();
+  const { restaurantUsername } = router.query;       
+
+  useEffect(() => {
+    if (!token) {
+      router.replace('/login');                       
+    } else if (
+      restaurantUsername &&                           
+      user?.restaurantUsername &&                    
+      restaurantUsername !== user.restaurantUsername  
+    ) {
+      router.replace(`/${user.restaurantUsername}/dashboard`);
+    }
+  }, [token, restaurantUsername]);
+
+  return token ? children : null;
+}

--- a/Source Code/chowhub/src/pages/login.js
+++ b/Source Code/chowhub/src/pages/login.js
@@ -1,3 +1,87 @@
-export default function Login() {
-  return <div>this is the login page</div>;
+import { useSetAtom, useAtomValue } from 'jotai';
+import { tokenAtom, userAtom } from '@/store/atoms';
+import { apiFetch } from '@/lib/api';
+import { toast } from 'react-toastify';
+import { useRouter } from 'next/router';
+import Top from '@/components/Top';
+import { Header } from '@/components/Header';
+import styles from '../pages/create-restaurant/createRes.module.css';
+import { Form, Button, Container } from 'react-bootstrap';
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+export default function LoginPage() {
+  const setToken = useSetAtom(tokenAtom);
+  const setUser  = useSetAtom(userAtom);
+  const token    = useAtomValue(tokenAtom);
+  const user     = useAtomValue(userAtom);
+  const router   = useRouter();
+
+  /* ★ Redirect to dashboard if already logged in */
+  useEffect(() => {
+    if (token && user?.restaurantUsername) {
+      router.replace(`/${user.restaurantUsername}/dashboard`);
+    }
+  }, [token, user, router]);
+
+  if (token && user?.restaurantUsername) return null;
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const body = Object.fromEntries(new FormData(e.target));
+    try {
+      const res = await apiFetch('/auth/login', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+      setToken(res.token);
+      setUser(res.user);
+      toast.success('Logged in!');
+      router.push(`/${res.user.restaurantUsername}/dashboard`);
+    } catch (err) {
+      toast.error(err.message);
+    }
+  }
+
+  return (
+    <>
+      <Top />
+      <Header title="Sign In to ChowHub" image="/images/create-res-header.jpg" />
+      <Container className="mt-5">
+        <Form
+          onSubmit={handleSubmit}
+          className={`bg-dark text-light p-4 rounded shadow ${styles.formWrapper}`}
+        >
+          <Form.Group className="mb-3">
+            <Form.Label>Username</Form.Label>
+            <Form.Control name="username" required className={styles.inputLarge} />
+          </Form.Group>
+          <Form.Group className="mb-4"> {/* Kept mb-4 for spacing before the action row */}
+            <Form.Label>Password</Form.Label>
+            <Form.Control
+              name="password"
+              type="password"
+              required
+              className={styles.inputLarge}
+            />
+          </Form.Group>
+
+          <div className="d-flex align-items-center mt-3">
+            <Button
+              type="submit"
+              className={`btn btn-success ${styles.registerBtn}`}
+            >
+              Login
+            </Button>
+            <Link
+              href="/forgot-password"
+              className="ms-3 text-white text-decoration-underline"
+            >
+              <small>Forgot password?</small>
+            </Link>
+          </div>
+        </Form>
+      </Container>
+    </>
+  );
 }

--- a/Source Code/chowhub/src/store/atoms.js
+++ b/Source Code/chowhub/src/store/atoms.js
@@ -1,0 +1,6 @@
+// src/store/atoms.js
+import { atomWithStorage } from 'jotai/utils';
+
+export const tokenAtom = atomWithStorage('token', null);
+export const userAtom  = atomWithStorage('user',  null);
+


### PR DESCRIPTION
• added tokenAtom & userAtom with localStorage persistence (Jotai)
• enhanced apiFetch to auto‑inject Bearer token + toast 401
• created Login page styled like Register, with “Forgot password?” link
• redirects existing sessions to /<restaurantUsername>/dashboard
• added Protected wrapper 
• Logout button clears atoms & returns to /login